### PR TITLE
Add publish time and storage stats benchmarks for multiple batch sizes

### DIFF
--- a/bench/src/micro_benchmark.rs
+++ b/bench/src/micro_benchmark.rs
@@ -20,20 +20,20 @@ const RUNS: usize = 10;
 const PRECISION: usize = 100;
 
 /// The number of key-values pair in the state tree.
-const DEFAULT_TREE_ENTRIES: u64 = 1_000;
+const DEFAULT_NUM_TREE_ENTRIES: u64 = 1_000;
 
 /// Run micro-benchmarks for every CPU-intensive operation.
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let tree_entries = match args.len() {
-        x if x > 1 => args[1].parse().unwrap_or(DEFAULT_TREE_ENTRIES),
-        _ => DEFAULT_TREE_ENTRIES,
+    let num_tree_entries = match args.len() {
+        x if x > 1 => args[1].parse().unwrap_or(DEFAULT_NUM_TREE_ENTRIES),
+        _ => DEFAULT_NUM_TREE_ENTRIES,
     };
     println!("Starting micro-benchmarks:");
 
     // Run all micro-benchmarks.
-    create_notification(tree_entries);
-    verify_notification(tree_entries);
+    create_notification(num_tree_entries);
+    verify_notification(num_tree_entries);
     create_vote();
     verify_vote();
     aggregate_certificate();
@@ -73,7 +73,7 @@ where
 
 /// Benchmark the creation of a publish notification.
 fn create_notification(tree_entries: u64) {
-    let akd_storage_path = ".micro_benchmark_adk_storage";
+    let akd_storage_path = ".micro_benchmark_akd_storage";
     struct Data(KeyPair);
 
     let setup = || {

--- a/bench/src/micro_benchmark.rs
+++ b/bench/src/micro_benchmark.rs
@@ -1,7 +1,6 @@
 mod utils;
 
 use akd::storage::memory::AsyncInMemoryDatabase;
-use akd::storage::Storage;
 use akd::AkdLabel;
 use akd::AkdValue;
 use config::Committee;

--- a/bench/src/micro_benchmark.rs
+++ b/bench/src/micro_benchmark.rs
@@ -50,10 +50,8 @@ fn main() {
     verify_certificate();
     publish_with_different_batch_sizes(true);
     publish_with_different_batch_sizes(false);
-    // AsyncInMemoryDatabase doesn't implement a useful log_metrics at the moment.
-    // AsyncInMemoryDatabase does implement one (print_stats) but it is compiled with the public-tests feature
-    // and requires changes to the AKD library implementation of it to actually print it in log_metrics.
-    storage_stats_with_different_batch_sizes(true);
+    // AKD in-memory storage implementations don't have stats as of now. Disabling this one.
+    // storage_stats_with_different_batch_sizes(true);
     // RocksDB stats.
     storage_stats_with_different_batch_sizes(false);
 }

--- a/bench/src/micro_benchmark.rs
+++ b/bench/src/micro_benchmark.rs
@@ -1,5 +1,9 @@
 mod utils;
 
+use akd::storage::memory::AsyncInMemoryDatabase;
+use akd::storage::Storage;
+use akd::AkdLabel;
+use akd::AkdValue;
 use config::Committee;
 use crypto::KeyPair;
 use futures::executor::block_on;
@@ -11,16 +15,23 @@ use statistical::{mean, standard_deviation};
 use std::time::Instant;
 use storage::akd_storage::AkdStorage;
 use test_utils::{certificate, committee, keys, notification, votes};
-use utils::{proof, proof_with_storage};
+use utils::{proof, proof_with_storage, publish_with_storage_stats};
 
-/// The number of runs used to compute statistics.
-const RUNS: usize = 10;
+use crate::utils::{generate_key_entries, publish_with_storage};
 
-/// The number measures to constitute a run (to smooth bootstrapping).
-const PRECISION: usize = 100;
+const AKD_STORAGE_PATH: &str = ".micro_benchmark_akd_storage";
+
+/// The default number of runs used to compute statistics.
+const DEFAULT_RUNS: u64 = 10;
+
+/// The default number measures to constitute a run (to smooth bootstrapping).
+const DEFAULT_PRECISION: u64 = 1;
 
 /// The number of key-values pair in the state tree.
 const DEFAULT_NUM_TREE_ENTRIES: u64 = 1_000;
+
+const KEY_ENTRY_BATCH_SIZES: &'static [u64] =
+    &[1, 10, 100, 1_000 /*, 10_000, 100_000, 1_000_000*/];
 
 /// Run micro-benchmarks for every CPU-intensive operation.
 fn main() {
@@ -38,12 +49,20 @@ fn main() {
     verify_vote();
     aggregate_certificate();
     verify_certificate();
+    publish_with_different_batch_sizes(true);
+    publish_with_different_batch_sizes(false);
+    // AsyncInMemoryDatabase doesn't implement a useful log_metrics at the moment.
+    // AsyncInMemoryDatabase does implement one (print_stats) but it is compiled with the public-tests feature
+    // and requires changes to the AKD library implementation of it to actually print it in log_metrics.
+    storage_stats_with_different_batch_sizes(true);
+    // RocksDB stats.
+    storage_stats_with_different_batch_sizes(false);
 }
 
 /// Run a single micro-benchmark.
 /// The `setup` function is executed before starting the timer and produces all the parameters needed for the
 /// benchmark. The `run` function is executed multiple times using the setup data (as references).
-fn bench<Setup, Run, Data, Result>(id: &str, setup: Setup, run: Run)
+fn bench<Setup, Run, Data, Result>(id: &str, setup: Setup, run: Run, num_runs: u64, precision: u64)
 where
     Setup: FnOnce() -> Data,
     Run: Fn(&Data) -> Result,
@@ -53,18 +72,18 @@ where
 
     // Run the function to benchmark a number of times.
     let mut data = Vec::new();
-    for _ in 0..RUNS {
+    for _ in 0..num_runs {
         let now = Instant::now();
-        for _ in 0..PRECISION {
+        for _ in 0..precision {
             let _result = run(&inputs);
         }
         let elapsed = now.elapsed().as_millis() as f64;
-        data.push(elapsed / PRECISION as f64);
+        data.push(elapsed / precision as f64);
     }
 
     // Display the results to stdout.
     println!(
-        "  {:>7.2} +/- {:<5.2} ms {:.>30}",
+        "  {:>7.2} +/- {:<5.2} ms {:.>50}",
         mean(&data),
         standard_deviation(&data, None),
         id
@@ -73,7 +92,6 @@ where
 
 /// Benchmark the creation of a publish notification.
 fn create_notification(tree_entries: u64) {
-    let akd_storage_path = ".micro_benchmark_akd_storage";
     struct Data(KeyPair);
 
     let setup = || {
@@ -84,14 +102,87 @@ fn create_notification(tree_entries: u64) {
     let run = |data: &Data| {
         let Data(keypair) = data;
 
-        let _ = std::fs::remove_dir_all(&akd_storage_path);
-        let db = AkdStorage::new(akd_storage_path);
+        let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+        let db = AkdStorage::new(AKD_STORAGE_PATH);
         let (_, root, proof) = block_on(proof_with_storage(tree_entries, db));
         PublishNotification::new(root, proof, 1, keypair)
     };
 
-    bench("create notification", setup, run);
-    let _ = std::fs::remove_dir_all(&akd_storage_path);
+    bench(
+        "create notification",
+        setup,
+        run,
+        DEFAULT_RUNS,
+        DEFAULT_PRECISION,
+    );
+    let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+}
+
+/// Wrapper around publish with multiple batch sizes.
+fn publish_with_different_batch_sizes(use_in_memory_db: bool) {
+    for batch_size in KEY_ENTRY_BATCH_SIZES {
+        publish(*batch_size, use_in_memory_db);
+    }
+}
+
+/// Benchmark the publish operation given different number of keys to publish.
+fn publish(num_tree_entries: u64, use_in_memory_db: bool) {
+    struct Data(Vec<(AkdLabel, AkdValue)>);
+    // Prepare key entries to be used for the bench.
+    let setup = || Data(generate_key_entries(num_tree_entries));
+
+    let run = |data: &Data| {
+        let Data(key_entries) = data;
+
+        // Decide what type of database to use (in-memory or persistent).
+        if use_in_memory_db {
+            let db = AsyncInMemoryDatabase::new();
+            block_on(publish_with_storage(key_entries.to_vec(), db));
+        } else {
+            // Clean up database file pre-bench.
+            let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+
+            let db = AkdStorage::new(AKD_STORAGE_PATH);
+            block_on(publish_with_storage(key_entries.to_vec(), db));
+        }
+    };
+
+    // Construct bench id to display.
+    let db_type_prefix = if use_in_memory_db {
+        "in_memory"
+    } else {
+        "persistent"
+    };
+    let bench_id = format!("publish_batch_size_{}_{}", num_tree_entries, db_type_prefix);
+
+    // Bench!
+    bench(&bench_id, setup, run, DEFAULT_RUNS, 1);
+
+    // Bench clean up.
+    let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+}
+
+/// Wrapper for storage stats of multiple batch sizes.
+fn storage_stats_with_different_batch_sizes(use_in_memory_db: bool) {
+    for batch_size in KEY_ENTRY_BATCH_SIZES {
+        storage_stats(*batch_size, use_in_memory_db);
+    }
+}
+
+/// Prints storage stats info after publishing given number of keys.
+fn storage_stats(num_tree_entries: u64, use_in_memory_db: bool) {
+    if use_in_memory_db {
+        let db = AsyncInMemoryDatabase::new();
+        block_on(publish_with_storage_stats(num_tree_entries, db));
+    } else {
+        let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+
+        let db = AkdStorage::new(AKD_STORAGE_PATH);
+        block_on(publish_with_storage_stats(num_tree_entries, db));
+
+        // Clean up post-publish
+        let _ = std::fs::remove_dir_all(&AKD_STORAGE_PATH);
+    }
 }
 
 /// Benchmark the verification of a publish notification.
@@ -110,7 +201,13 @@ fn verify_notification(tree_entries: u64) {
         block_on(notification.verify(committee, previous_root))
     };
 
-    bench("verify notification", setup, run);
+    bench(
+        "verify notification",
+        setup,
+        run,
+        DEFAULT_RUNS,
+        DEFAULT_PRECISION,
+    );
 }
 
 /// Benchmark the creation of a publish vote.
@@ -127,7 +224,7 @@ fn create_vote() {
         PublishVote::new(notification, keypair)
     };
 
-    bench("create vote", setup, run);
+    bench("create vote", setup, run, DEFAULT_RUNS, DEFAULT_PRECISION);
 }
 
 /// Benchmark the verification of a publish vote.
@@ -144,7 +241,7 @@ fn verify_vote() {
         vote.verify(committee)
     };
 
-    bench("verify vote", setup, run);
+    bench("verify vote", setup, run, DEFAULT_RUNS, DEFAULT_PRECISION);
 }
 
 /// Benchmark the aggregation of a quorum of votes into a certificate.
@@ -170,7 +267,13 @@ fn aggregate_certificate() {
         }
     };
 
-    bench("aggregate certificate", setup, run);
+    bench(
+        "aggregate certificate",
+        setup,
+        run,
+        DEFAULT_RUNS,
+        DEFAULT_PRECISION,
+    );
 }
 
 /// Benchmark the verification of a certificate.
@@ -189,5 +292,11 @@ fn verify_certificate() {
         certificate.verify(committee)
     };
 
-    bench("verify certificate", setup, run);
+    bench(
+        "verify certificate",
+        setup,
+        run,
+        DEFAULT_RUNS,
+        DEFAULT_PRECISION,
+    );
 }

--- a/bench/src/utils.rs
+++ b/bench/src/utils.rs
@@ -89,7 +89,7 @@ where
     let key_entries = generate_key_entries(num_key_entries);
     akd.publish::<Blake3>(key_entries).await.unwrap();
 
-    // More detailed stats.
+    // Display storage stats.
     println!("Number of key entries: {}", num_key_entries);
     db.log_metrics(log::Level::Debug).await;
 }

--- a/bench/src/utils.rs
+++ b/bench/src/utils.rs
@@ -6,6 +6,7 @@ use akd::{
     storage::{
         memory::AsyncInMemoryDatabase,
         types::{AkdLabel, AkdValue},
+        Storage,
     },
 };
 use bytes::{BufMut, Bytes, BytesMut};
@@ -15,6 +16,14 @@ use messages::{
     publish::{Proof, PublishCertificate, PublishNotification, PublishVote},
     Blake3, IdPToWitnessMessage, Root,
 };
+
+use std::fs;
+
+use crate::AKD_STORAGE_PATH;
+use storage::akd_storage::AkdStorage;
+
+// The size of the AkdLabel and AkdValue
+const LABEL_VALUE_SIZE_BYTES: usize = 32;
 
 /// Create a publish proof from a tree with the specified number of key-value pairs and an in-memory storage.
 pub async fn proof(entries: u64) -> (Root, Root, Proof) {
@@ -27,23 +36,8 @@ pub async fn proof_with_storage<AkdStorage>(num_entries: u64, db: AkdStorage) ->
 where
     AkdStorage: akd::storage::Storage + Sync + Send + 'static,
 {
-    // Create the list of 64-bytes key-value pairs (in memory).
-    let size = 32;
-    let mut key = BytesMut::with_capacity(size);
-    let mut value = BytesMut::with_capacity(size);
-    let items: Vec<_> = (0..num_entries)
-        .map(|i| {
-            key.put_u64(i);
-            key.resize(size, 0u8);
-            let k = key.split().freeze();
-
-            value.put_u64(i);
-            value.resize(size, 0u8);
-            let v = value.split().freeze();
-
-            (AkdLabel(k.to_vec()), AkdValue(v.to_vec()))
-        })
-        .collect();
+    // Create the list of key-value pairs (in memory).
+    let key_entries = generate_key_entries(num_entries);
 
     // Create a test tree with the specified number of key-values.
     let vrf = HardCodedAkdVRF {};
@@ -56,7 +50,7 @@ where
         .await
         .unwrap();
 
-    akd.publish::<Blake3>(items).await.unwrap();
+    akd.publish::<Blake3>(key_entries).await.unwrap();
 
     let current_azks = akd.retrieve_current_azks().await.unwrap();
     let end = akd
@@ -67,6 +61,60 @@ where
     // Generate the audit proof.
     let proof = akd.audit::<Blake3>(0, 1).await.unwrap();
     (start, end, proof)
+}
+
+/// Performs a publish with number of key-value pairs. Pair creation must be done outside
+/// of this function to *only* measure the publish time.
+/// Note that the measurements WILL include directory creation times which should not
+/// affect performance too much.
+pub async fn publish_with_storage<AkdStorage>(
+    key_entries: Vec<(AkdLabel, AkdValue)>,
+    db: AkdStorage,
+) where
+    AkdStorage: akd::storage::Storage + Sync + Send,
+{
+    let vrf = HardCodedAkdVRF {};
+    let akd = Directory::new::<Blake3>(&db, &vrf, false).await.unwrap();
+
+    akd.publish::<Blake3>(key_entries).await.unwrap();
+}
+
+/// Performs a publish operation with given number of key entries and prints the
+/// storage stats. It is not meant to be used in benches.
+pub async fn publish_with_storage_stats<AkdStorage>(num_key_entries: u64, db: AkdStorage)
+where
+    AkdStorage: akd::storage::Storage + Sync + Send,
+{
+    // Setup
+    let vrf = HardCodedAkdVRF {};
+    let akd = Directory::new::<Blake3>(&db, &vrf, false).await.unwrap();
+
+    // Generate keys and publish.
+    // It is okay to include key generation here since this function
+    // is not used in benches per-se but used for obtaining storage stats.
+    let key_entries = generate_key_entries(num_key_entries);
+    akd.publish::<Blake3>(key_entries).await.unwrap();
+
+    // More detailed stats.
+    println!("Number of key entries: {}", num_key_entries);
+    db.log_metrics(log::Level::Debug).await;
+}
+
+pub fn generate_key_entries(num_entries: u64) -> Vec<(AkdLabel, AkdValue)> {
+    let mut label = BytesMut::with_capacity(LABEL_VALUE_SIZE_BYTES);
+    let mut value = BytesMut::with_capacity(LABEL_VALUE_SIZE_BYTES);
+
+    (0..num_entries)
+        .map(|i| {
+            label.put_u64(i);
+            let l = label.split().freeze();
+
+            value.put_u64(i);
+            let v = value.split().freeze();
+
+            (AkdLabel(l.to_vec()), AkdValue(v.to_vec()))
+        })
+        .collect()
 }
 
 /// Make dumb (but valid) publish notifications.

--- a/bench/src/utils.rs
+++ b/bench/src/utils.rs
@@ -23,7 +23,7 @@ pub async fn proof(entries: u64) -> (Root, Root, Proof) {
 }
 
 /// Create a publish proof from a tree with the specified number of key-value pairs and storage.
-pub async fn proof_with_storage<AkdStorage>(entries: u64, db: AkdStorage) -> (Root, Root, Proof)
+pub async fn proof_with_storage<AkdStorage>(num_entries: u64, db: AkdStorage) -> (Root, Root, Proof)
 where
     AkdStorage: akd::storage::Storage + Sync + Send + 'static,
 {
@@ -31,7 +31,7 @@ where
     let size = 32;
     let mut key = BytesMut::with_capacity(size);
     let mut value = BytesMut::with_capacity(size);
-    let items: Vec<_> = (0..entries)
+    let items: Vec<_> = (0..num_entries)
         .map(|i| {
             key.put_u64(i);
             key.resize(size, 0u8);

--- a/bench/src/utils.rs
+++ b/bench/src/utils.rs
@@ -6,7 +6,6 @@ use akd::{
     storage::{
         memory::AsyncInMemoryDatabase,
         types::{AkdLabel, AkdValue},
-        Storage,
     },
 };
 use bytes::{BufMut, Bytes, BytesMut};
@@ -16,11 +15,6 @@ use messages::{
     publish::{Proof, PublishCertificate, PublishNotification, PublishVote},
     Blake3, IdPToWitnessMessage, Root,
 };
-
-use std::fs;
-
-use crate::AKD_STORAGE_PATH;
-use storage::akd_storage::AkdStorage;
 
 // The size of the AkdLabel and AkdValue
 const LABEL_VALUE_SIZE_BYTES: usize = 32;

--- a/storage/src/akd_storage.rs
+++ b/storage/src/akd_storage.rs
@@ -40,7 +40,9 @@ impl Clone for AkdStorage {
 
 #[async_trait]
 impl akd::storage::Storage for AkdStorage {
-    async fn log_metrics(&self, _level: log::Level) {}
+    async fn log_metrics(&self, _level: log::Level) {
+       self.database.read().await.log_metrics();
+    }
 
     async fn begin_transaction(&self) -> bool {
         self.transaction.begin_transaction().await
@@ -120,7 +122,9 @@ impl akd::storage::Storage for AkdStorage {
         AkdStorage::get::<St>(self, id).await
     }
 
-    async fn flush_cache(&self) {}
+    async fn flush_cache(&self) {
+        self.database.read().await.flush_cache();
+    }
 
     async fn get_user_data(&self, _username: &AkdLabel) -> Result<KeyData, AkdStorageError> {
         unimplemented!()

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -4,6 +4,8 @@ pub mod akd_storage;
 pub type StoreError = rocksdb::Error;
 type StoreResult<T> = Result<T, StoreError>;
 
+use rocksdb::perf;
+
 /// Wrapper around rocksdb.
 pub struct Storage(rocksdb::DB);
 
@@ -22,5 +24,35 @@ impl Storage {
     /// Write a value to storage.
     pub fn write(&self, key: &[u8], value: &[u8]) -> StoreResult<()> {
         self.0.put(key, value)
+    }
+
+    pub fn log_metrics(&self) {
+        // Flush cache first.
+        // TODO(eoz): Figure out why flush is ineffective
+        // Sample log:
+        // Memory usage stats:
+        // Mem table total: 2048, Mem table unflushed: 2048, Mem table readers total: 4509, Cache total: 0
+        self.flush_cache();
+
+        // Print database stats.
+        if let Ok(Some(db_stats)) = self.0.property_value("rocksdb.dbstats") {
+            println!("{}", db_stats);
+        } else {
+            panic!("Error retrieving DB stats.");
+        }
+
+        // Print memory stats.
+        if let Ok(mem_stats) = perf::get_memory_usage_stats(Some(&[&self.0]), None) {
+            println!("Memory usage stats: Mem table total: {}, Mem table unflushed: {}, Mem table readers total: {}, Cache total: {}",
+            mem_stats.mem_table_total, mem_stats.mem_table_unflushed, mem_stats.mem_table_readers_total, mem_stats.cache_total);
+        } else {
+            panic!("Error retrieving memory usage stats.");
+        }
+    }
+
+    pub fn flush_cache(&self) {
+        if self.0.flush().is_err() {
+            panic!("Panic flushing the cache.");
+        }
     }
 }


### PR DESCRIPTION
Sample run for publishing with different batch sizes:

```
Starting micro-benchmarks:
  2812.80 +/- 54.75 ms ...............................create notification
   623.20 +/- 24.46 ms ...............................verify notification
     0.00 +/- 0.00  ms .......................................create vote
     0.00 +/- 0.00  ms .......................................verify vote
     0.00 +/- 0.00  ms .............................aggregate certificate
     1.00 +/- 0.00  ms ................................verify certificate
     2.20 +/- 0.42  ms ....................publish_batch_size_1_in_memory
    23.30 +/- 1.95  ms ...................publish_batch_size_10_in_memory
   223.00 +/- 3.30  ms ..................publish_batch_size_100_in_memory
  2398.10 +/- 43.99 ms .................publish_batch_size_1000_in_memory
    32.50 +/- 10.26 ms ...................publish_batch_size_1_persistent
    51.20 +/- 6.30  ms ..................publish_batch_size_10_persistent
   264.90 +/- 11.73 ms .................publish_batch_size_100_persistent
  2625.70 +/- 57.50 ms ................publish_batch_size_1000_persistent
```

RocksDB storage stats sample:

```
** DB Stats **
Uptime(secs): 0.0 total, 0.0 interval
Cumulative writes: 6 writes, 6 keys, 6 commit groups, 1.0 writes per commit group, ingest: 0.00 GB, 0.07 MB/s
Cumulative WAL: 6 writes, 0 syncs, 6.00 writes per sync, written: 0.00 GB, 0.07 MB/s
Cumulative stall: 00:00:0.000 H:M:S, 0.0 percent
Interval writes: 6 writes, 6 keys, 6 commit groups, 1.0 writes per commit group, ingest: 0.00 MB, 0.07 MB/s
Interval WAL: 6 writes, 0 syncs, 6.00 writes per sync, written: 0.00 GB, 0.07 MB/s
Interval stall: 00:00:0.000 H:M:S, 0.0 percent

Memory usage stats: Mem table total: 2048, Mem table unflushed: 2048, Mem table readers total: 150, Cache total: 0
```

Questions:

- What is a good `DEFAULT_PRECISION` value to set? For 100, it takes a long time to run the benchmarks. Is only average of 10 runs acceptable?
- What batch sizes should we use for time + storage stats measurements? 10^x  where x is in [2, 5]?
- RocksDB's storage stats are limited. Is there anything else we are interested in from the [list](https://docs.rs/rocksdb/latest/rocksdb/properties/index.html) of stats? (The ones I printed were the ones I thought were most relevant.


To fix:
- [ ] RocksDB `flush()` is ineffective. The memory stats still shows unflushed data.